### PR TITLE
Allow passing rustix_use_libc cfg using RUSTFLAGS

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -229,6 +229,8 @@ const EXTRA_CHECK_CFGS: &[(Option<Mode>, &'static str, Option<&[&'static str]>)]
     // FIXME: Used by proc-macro2, but we should not be triggering on external dependencies.
     (Some(Mode::Rustc), "span_locations", None),
     (Some(Mode::ToolRustc), "span_locations", None),
+    // Can be passed in RUSTFLAGS to prevent direct syscalls in rustix.
+    (None, "rustix_use_libc", None),
 ];
 
 /// A structure representing a Rust compiler.


### PR DESCRIPTION
Before this would error with

```
error: unexpected `rustix_use_libc` as condition name
  |
  = note: `-D unexpected-cfgs` implied by `-D warnings`
  = help: was set with `--cfg` but isn't in the `--check-cfg` expected names
```

I'm setting rustix_use_libc when testing bootstrapping rustc with cg_clif as I'm disabling inline asm here.